### PR TITLE
persistencia de inicio de sesión solucionada ✔️

### DIFF
--- a/src/app/features/auth/auth.service.ts
+++ b/src/app/features/auth/auth.service.ts
@@ -75,10 +75,11 @@ export class AuthService {
   logout() {
     this.removeTokenId();
     this.store.dispatch(AuthActions.logout({ loggedIn: false }));
+    this.router.navigate(['/home']);
   }
 
   setTokenId(res: Token) {
-    return localStorage.setItem('userData', JSON.stringify(res));
+    localStorage.setItem('userData', JSON.stringify(res));
   }
 
   getTokenId(what: string) {
@@ -87,7 +88,7 @@ export class AuthService {
   }
 
   removeTokenId() {
-    return localStorage.removeItem('userData');
+    localStorage.removeItem('userData');
   }
 
 }

--- a/src/app/shared/components/navbar/navbar.component.ts
+++ b/src/app/shared/components/navbar/navbar.component.ts
@@ -2,7 +2,6 @@ import { AuthService } from './../../../features/auth/auth.service';
 import { Component, OnInit } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { Observable } from 'rxjs';
-import { Router } from '@angular/router';
 import { AuthActions } from '../../stores/actions/auth.actions';
 import { fromAuth } from '../../stores/selectors/auth.selector';
 
@@ -14,18 +13,21 @@ import { fromAuth } from '../../stores/selectors/auth.selector';
 export class NavbarComponent implements OnInit {
   appTitle = 'MapIt';
   theme = false;
-  loggedIn$: Observable<boolean>;
+  loggedIn$?: Observable<boolean>;
 
   constructor(
     private store: Store,
-    private router: Router,
     private authService: AuthService
   ) {
     this.loggedIn$ = this.store.select(fromAuth.isLoggedIn);
+    console.log(this.loggedIn$);
   }
   ngOnInit() {
-    const token = localStorage.getItem('token');
-    if (!token) {
+    // const token = localStorage.getItem('token');
+    const token = this.authService.getTokenId('token');
+    if (token) {
+      this.store.dispatch(AuthActions.login({ loggedIn: true }));
+    } else {
       this.logout();
     }
   }
@@ -46,6 +48,5 @@ export class NavbarComponent implements OnInit {
 
   logout() {
     this.authService.logout();
-    this.router.navigate(['/home']);
   }
 }


### PR DESCRIPTION
# Persistencia de inicio de sesión al actualizar la pagina

- Se identificó el error que no permitía mantener el inicio de sesión en el componente "navbar".
- Se procedió a realizar los cambios en el "ngOnInit( )": 

> Se inicializaba la variable "loggedIn$" en el constructor, pero no se inicializaba el **store** a **loggedIn: true** si el "ngOnInit( )" encontraba un "token"

- [x] Identificar el error
- [x] Solucionado